### PR TITLE
Correct invalid keywords.txt KEYWORD_TOKENTYPE

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -158,7 +158,7 @@ clearDisplayAndDisableButtonsAndSliders	KEYWORD2
 # from BDSlider.h
 resetAllSliders	KEYWORD2
 activateAllSliders	KEYWORD2
-deactivateAllSliders	KEYWORD2#
+deactivateAllSliders	KEYWORD2
 init	KEYWORD2
 drawSlider	KEYWORD2
 drawBorder	KEYWORD2


### PR DESCRIPTION
Use of an invalid KEYWORD_TOKENTYPE value in keywords.txt causes the keyword to be colored by the default editor.function.style (as used by KEYWORD2, KEYWORD3, LITERAL2) in Arduino IDE 1.6.5 and newer. On Arduino IDE 1.6.4 and older this will cause the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype